### PR TITLE
add support for building 'atm' on OSX

### DIFF
--- a/fonts/atm/atm.pro
+++ b/fonts/atm/atm.pro
@@ -1,3 +1,4 @@
+QT_CONFIG -= no-pkg-config
 CONFIG += c++11 link_pkgconfig
 TEMPLATE += app
 TARGET = atm


### PR DESCRIPTION
I had to add this line to be able to build atm on Mac with qmake from homebrew's Qt 5.6.0.

Qmake's pkg-config support is disabled by default on mac, apparently:
http://stackoverflow.com/a/16972067
